### PR TITLE
fix: Correct shields.io badge URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Awesome Dashboard
 
+[![npm version](https://img.shields.io/npm/v/awesome-dashboard.svg)](https://www.npmjs.com/package/awesome-dashboard)
+[![License](https://img.shields.io/github/license/linqianru234-wq/eval-awesome-dashboard.svg)](LICENSE)
+[![GitHub issues](https://img.shields.io/github/issues/linqianru234-wq/eval-awesome-dashboard.svg)](https://github.com/linqianru234-wq/eval-awesome-dashboard/issues)
+
 A full-stack web application.
 
 ## Getting Started


### PR DESCRIPTION
## Summary
- Added correct shields.io badge URLs for npm version, license, and GitHub issues
- Fixed badge links to point to the correct repository: linqianru234-wq/eval-awesome-dashboard

## Test plan
- [ ] Verify badge images render correctly
- [ ] Check that links navigate to the correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)